### PR TITLE
change the class used for the selector so that it won't conflict with other uses of "dropdown-toggle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ the drop-down is toggled closed after the user selectes a date/time.
 ### Drop-down component with associated input box.
 ```html
 <div class="dropdown">
-    <a class="dropdown-toggle" id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="#">
+    <a class="dropdown-toggle my-toggle-select" id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="#">
         <div class="input-append"><input type="text" class="input-large" data-ng-model="data.date"><span class="add-on"><i
                 class="icon-calendar"></i></span>
         </div>
     </a>
     <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
         <datetimepicker data-ng-model="data.date"
-                        data-datetimepicker-config="{ dropdownSelector: '.dropdown-toggle' }"></datetimepicker>
+                        data-datetimepicker-config="{ dropdownSelector: '.my-toggle-select' }"></datetimepicker>
     </ul>
 </div>
 ```


### PR DESCRIPTION
I found that using only "dropdown-toggle" as the selector would conflict is real bootstrap menus were in use in the navbar.  By changing the selector to something unique this problem goes away.
