### PR TITLE
returnType config option allows return of a moment() value to ngModel

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -18,12 +18,13 @@ angular.module('ui.bootstrap.datetimepicker', [])
     startView: 'day',
     minView: 'minute',
     minuteStep: 5,
-    dropdownSelector: null
+    dropdownSelector: null,
+    returnType: 'date'
   })
   .constant('dateTimePickerConfigValidation', function (configuration) {
     "use strict";
 
-    var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector'];
+    var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'returnType'];
 
     for (var prop in configuration) {
       if (configuration.hasOwnProperty(prop)) {
@@ -35,6 +36,7 @@ angular.module('ui.bootstrap.datetimepicker', [])
 
     // Order of the elements in the validViews array is significant.
     var validViews = ['minute', 'hour', 'day', 'month', 'year'];
+    var validReturnTypes = ['moment', 'date'];
 
     if (validViews.indexOf(configuration.startView) < 0) {
       throw ("invalid startView value: " + configuration.startView);
@@ -56,6 +58,9 @@ angular.module('ui.bootstrap.datetimepicker', [])
     }
     if (configuration.dropdownSelector !== null && !angular.isString(configuration.dropdownSelector)) {
       throw ("dropdownSelector must be a string");
+    }
+    if (validReturnTypes.indexOf(configuration.returnType) < 0) {
+      throw ("returnType must be either moment or date. Received: " + configuration.returnType);
     }
   }
 )
@@ -302,7 +307,7 @@ angular.module('ui.bootstrap.datetimepicker', [])
             if (angular.isFunction(scope.onSetTime)) {
               scope.onSetTime(newDate, scope.ngModel);
             }
-            scope.ngModel = newDate;
+            scope.ngModel = configuration.returnType === 'date' ? newDate : moment(newDate);
             return dataFactory[scope.data.currentView](unixDate);
           }
         };

--- a/test/returnType.spec.js
+++ b/test/returnType.spec.js
@@ -1,0 +1,43 @@
+/*globals describe, beforeEach, it, expect, module, inject */
+
+/**
+ * @license angular-bootstrap-datetimepicker
+ * (c) 2013 Knight Rider Consulting, Inc. http://www.knightrider.com
+ * License: MIT
+ */
+
+/**
+ *
+ *    @author       A.M. Knight
+ *    @since        1/29/14
+ */
+
+describe('returnType', function () {
+  'use strict';
+  var $rootScope, $compile;
+  beforeEach(module('ui.bootstrap.datetimepicker'));
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.date = null;
+  }));
+
+  describe('throws exception', function () {
+    it('if returnType is not a valid returnType', function () {
+      function compile() {
+        $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ returnType: \'foo\' }"></datetimepicker>')($rootScope);
+      }
+
+      expect(compile).toThrow("returnType must be either moment or date. Received: foo");
+    });
+  });
+  describe('does NOT throw exception for valid values', function () {
+    it('if value is in valid return types', function () {
+      var validReturnTypes = ['moment', 'date'];
+
+      for (var i = 0; i < validReturnTypes.length; i++) {
+        $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ returnType: \'' + validReturnTypes[i] + '\' }"></datetimepicker>')($rootScope);
+      }
+    });
+  });
+});


### PR DESCRIPTION
(First pull request so bear with me if I've done something wrong)

As wlingke stated in issue #30 moment is used for formatting and parsing already and thus this fits very easily within an angular app that makes use of moment for date storage. My use case is similar to his in that I need to store the ngModel value as a moment and not a date.

From a usability standpoint the way I've implemented it the default is to behave as it does now, returning a js date object. It can then be changed by passing in returnType: 'moment' to the directive's configuration. 

I've included karma tests as well.