### PR TITLE
Added config option to restart at startView

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ String. 'minute'
 
 The lowest view that the datetimepicker should show.
 
+### restartView
+
+Boolean.  Default: false
+
+Show the starting view if selecting a new date/time.
+
 ### minuteStep
 
 Number.  Default: 5

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -19,12 +19,13 @@ angular.module('ui.bootstrap.datetimepicker', [])
     minuteStep: 5,
     minView: 'minute',
     startView: 'day',
-    weekStart: 0
+    weekStart: 0,
+    restartView: false
   })
   .constant('dateTimePickerConfigValidation', function (configuration) {
     "use strict";
 
-    var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'weekStart'];
+    var validOptions = ['startView', 'minView', 'restartView', 'minuteStep', 'dropdownSelector', 'weekStart'];
 
     for (var prop in configuration) {
       if (configuration.hasOwnProperty(prop)) {
@@ -311,7 +312,12 @@ angular.module('ui.bootstrap.datetimepicker', [])
               scope.onSetTime(newDate, scope.ngModel);
             }
             scope.ngModel = newDate;
-            return dataFactory[scope.data.currentView](unixDate);
+            if (configuration.restartView) {
+              return dataFactory[configuration.startView](unixDate);
+            }
+            else {
+              return dataFactory[scope.data.currentView](unixDate);
+            }
           }
         };
 


### PR DESCRIPTION
When used as a dropdown, the picker always opens at the _minute_ level after a date/time is set. This makes it difficult to change the date (requiring 2 extra clicks to get to the _day_ view) and makes the it work differently than most dropdown pickers.

I've added a config option to reset back to the _startView_ each time a date/time is set.
