### PR TITLE
Fixing typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Number.  Default: 0
 Allows to set a week's starting day. Should be between 0 and 6.
 
 ```html
-<datetimepicker data-ng-model="data.date" date-datetimepicker-config="{'weekStart': 1}"></datetimepicker>
+<datetimepicker data-ng-model="data.date" data-datetimepicker-config="{'weekStart': 1}"></datetimepicker>
 ```
 
 ## Working with ng-model


### PR DESCRIPTION
you write **date-**\* instead of **data-**\* in attribute

Also I don't know why one change on type also includes this information about removing and adding lines under section "working with ng-model"
