### PR TITLE
Allow date format for the input binding.

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -20,7 +20,7 @@ angular.module('ui.bootstrap.datetimepicker', [])
     minView: 'minute',
     startView: 'day',
     weekStart: 0,    
-    format: 'yyyy-MM-dd hh:mm:ss'
+    format: 'yyyy-MM-dd HH:mm:ss'
   })
   .constant('dateTimePickerConfigValidation', function (configuration) {
     "use strict";


### PR DESCRIPTION
<div class="dropdown">
  <a class="dropdown-toggle" id="taskStartToggle" role="button" data-toggle="dropdown" data-target="#" href="#">
    <div class="input-group">
      <input placeholder="yyyy-MM-dd" type="text" class="form-control" data-ng-model="task.start" />
      <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
    </div>
  </a>
  <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
    <datetimepicker data-ng-model="task.start" data-datetimepicker-config="{ format: 'yyyy-MM-dd', minView: 'day', dropdownSelector: '#taskStartToggle' }"/>
  </ul>
</div>
