### PR TITLE
allow customization of prev/next icons

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -19,13 +19,15 @@ angular.module('ui.bootstrap.datetimepicker', [])
     minuteStep: 5,
     minView: 'minute',
     startView: 'day',
-    weekStart: 0
+    weekStart: 0,
+    previousIconClass: 'glyphicon glyphicon-arrow-left',
+    nextIconClass: 'glyphicon glyphicon-arrow-right'
   })
   .directive('datetimepicker', ['dateTimePickerConfig', function (defaultConfig) {
     "use strict";
 
     var validateConfiguration = function (configuration) {
-      var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'weekStart'];
+      var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'weekStart', 'previousIconClass', 'nextIconClass'];
 
       for (var prop in configuration) {
         if (configuration.hasOwnProperty(prop)) {
@@ -77,13 +79,13 @@ angular.module('ui.bootstrap.datetimepicker', [])
         "       <tr>" +
         "           <th class='left'" +
         "               data-ng-click='changeView(data.currentView, data.leftDate, $event)'" +
-        "               ><i class='glyphicon glyphicon-arrow-left'/></th>" +
+        "               ><i ng-class='previousIconClass'/></th>" +
         "           <th class='switch' colspan='5'" +
         "               data-ng-click='changeView(data.previousView, data.currentDate, $event)'" +
         ">{{ data.title }}</th>" +
         "           <th class='right'" +
         "               data-ng-click='changeView(data.currentView, data.rightDate, $event)'" +
-        "             ><i class='glyphicon glyphicon-arrow-right'/></th>" +
+        "             ><i ng-class='nextIconClass'/></th>" +
         "       </tr>" +
         "       <tr>" +
         "           <th class='dow' data-ng-repeat='day in data.dayNames' >{{ day }}</th>" +
@@ -124,6 +126,9 @@ angular.module('ui.bootstrap.datetimepicker', [])
         angular.extend(configuration, defaultConfig, directiveConfig);
 
         validateConfiguration(configuration);
+
+        scope.previousIconClass = configuration.previousIconClass;
+        scope.nextIconClass = configuration.nextIconClass;
 
         var dataFactory = {
           year: function (unixDate) {

--- a/test/iconClass.spec.js
+++ b/test/iconClass.spec.js
@@ -1,0 +1,70 @@
+
+describe('iconClass', function () {
+  'use strict';
+  var $rootScope, $compile;
+  beforeEach(module('ui.bootstrap.datetimepicker'));
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.date = null;
+  }));
+
+  describe('previousIconClass', function () {
+    it('defaults to glyphicon-arrow-left', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var previousIcon = jQuery('.glyphicon-arrow-left', element);
+      expect(previousIcon.length).toEqual(1);
+      expect(previousIcon.parent().hasClass('left')).toBe(true);
+    });
+
+    it('can be set to custom string', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{previousIconClass: \'testPreviousIcon\'}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var previousIcon = jQuery('.testPreviousIcon', element);
+      expect(previousIcon.length).toEqual(1);
+      expect(previousIcon.parent().hasClass('left')).toBe(true);
+    });
+
+    it('can be set to custom array', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{previousIconClass: [\'testPreviousIcon1\', \'testPreviousIcon2\']}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var previousIcon = jQuery('.testPreviousIcon1.testPreviousIcon2', element);
+      expect(previousIcon.length).toEqual(1);
+      expect(previousIcon.parent().hasClass('left')).toBe(true);
+    });
+  });
+
+  describe('nextIconClass', function () {
+    it('defaults to glyphicon-arrow-right', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var nextIcon = jQuery('.glyphicon-arrow-right', element);
+      expect(nextIcon.length).toEqual(1);
+      expect(nextIcon.parent().hasClass('right')).toBe(true);
+    });
+
+    it('can be set to custom string', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{nextIconClass: \'testNextIcon\'}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var nextIcon = jQuery('.testNextIcon', element);
+      expect(nextIcon.length).toEqual(1);
+      expect(nextIcon.parent().hasClass('right')).toBe(true);
+    });
+
+    it('can be set to custom array', function () {
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{nextIconClass: [\'testNextIcon1\', \'testNextIcon2\']}"></datetimepicker>')($rootScope);
+
+      $rootScope.$digest();
+      var nextIcon = jQuery('.testNextIcon1.testNextIcon2', element);
+      expect(nextIcon.length).toEqual(1);
+      expect(nextIcon.parent().hasClass('right')).toBe(true);
+    });
+  });
+});
+


### PR DESCRIPTION
For those who do not use bootstrap's glyphicons, and would prefer to select a custom icon for the previous and next arrows, I added two attributes to the configuration object to do this (previousIconClass and nextIconClass). The values of these configuration attributes can be any valid input to the ngClass directive (string, array, object).

Let me know if you think this change belongs in the project, and if you'd like me to adjust anything. I have also included a few unit tests to cover the feature.
