### PR TITLE
Removed hardcoded dependency on JQuery when using a dropdown

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -303,7 +303,7 @@ angular.module('ui.bootstrap.datetimepicker', [])
             var tempDate = new Date(unixDate);
             var newDate = new Date(tempDate.getTime() + (tempDate.getTimezoneOffset() * 60000));
             if (configuration.dropdownSelector) {
-              jQuery(configuration.dropdownSelector).dropdown('toggle');
+              angular.element(document.querySelector(configuration.dropdownSelector)).parent().removeClass('open');
             }
             if (angular.isFunction(scope.onSetTime)) {
               scope.onSetTime(newDate, scope.ngModel);


### PR DESCRIPTION
Use angular.element() instead of JQuery() when closing the toggle. If JQuery is available angular.element will use the JQuery function otherwise it will use Angular's JQLite.
