### PR TITLE
fix table-striped matcher

### DIFF
--- a/src/css/datetimepicker.css
+++ b/src/css/datetimepicker.css
@@ -143,8 +143,8 @@
     border-radius: 4px;
     border: none;
 }
-.datetimepicker .table-striped > tbody > tr:nth-child(odd) > td, .table-striped > tbody > tr:nth-child(odd) > td,
-.datetimepicker .table-striped > tbody > tr:nth-child(odd) > td, .table-striped > tbody > tr:nth-child(odd) > th {
+.datetimepicker .table-striped > tbody > tr:nth-child(odd) > td, 
+.datetimepicker .table-striped > tbody > tr:nth-child(odd) > th {
   background-color: transparent;
 }
 .datetimepicker table tr td.minute:hover {


### PR DESCRIPTION
selector not inside .datetimepicker so style is being applied to all
tables
