### PR TITLE
more permissive angular version specifier

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "test*"
   ],
   "dependencies": {
-    "angular": "1.2.26",
+    "angular": ">= 1.2.26 < 2.0.0",
     "moment": "^2.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The documentation says it works on any Angular after 1.2.26. With this specific version modifier, it is causing conflicts with my other angular libraries.