### PR TITLE
Show current period (Issue #85)

### DIFF
--- a/src/css/datetimepicker.css
+++ b/src/css/datetimepicker.css
@@ -175,10 +175,10 @@
     cursor: default;
 }
 
-.datetimepicker table tr td.today,
-.datetimepicker table tr td.today:hover,
-.datetimepicker table tr td.today.disabled,
-.datetimepicker table tr td.today.disabled:hover {
+.datetimepicker table tr .today,
+.datetimepicker table tr .today:hover,
+.datetimepicker table tr .today.disabled,
+.datetimepicker table tr .today.disabled:hover {
     background-color: #fde19a;
     background-image: -moz-linear-gradient(top, #fdd49a, #fdf59a);
     background-image: -ms-linear-gradient(top, #fdd49a, #fdf59a);
@@ -193,37 +193,37 @@
     filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
 }
 
-.datetimepicker table tr td.today:hover,
-.datetimepicker table tr td.today:hover:hover,
-.datetimepicker table tr td.today.disabled:hover,
-.datetimepicker table tr td.today.disabled:hover:hover,
-.datetimepicker table tr td.today:active,
-.datetimepicker table tr td.today:hover:active,
-.datetimepicker table tr td.today.disabled:active,
-.datetimepicker table tr td.today.disabled:hover:active,
-.datetimepicker table tr td.today.active,
-.datetimepicker table tr td.today:hover.active,
-.datetimepicker table tr td.today.disabled.active,
-.datetimepicker table tr td.today.disabled:hover.active,
-.datetimepicker table tr td.today.disabled,
-.datetimepicker table tr td.today:hover.disabled,
-.datetimepicker table tr td.today.disabled.disabled,
-.datetimepicker table tr td.today.disabled:hover.disabled,
-.datetimepicker table tr td.today[disabled],
-.datetimepicker table tr td.today:hover[disabled],
-.datetimepicker table tr td.today.disabled[disabled],
-.datetimepicker table tr td.today.disabled:hover[disabled] {
+.datetimepicker table tr .today:hover,
+.datetimepicker table tr .today:hover:hover,
+.datetimepicker table tr .today.disabled:hover,
+.datetimepicker table tr .today.disabled:hover:hover,
+.datetimepicker table tr .today:active,
+.datetimepicker table tr .today:hover:active,
+.datetimepicker table tr .today.disabled:active,
+.datetimepicker table tr .today.disabled:hover:active,
+.datetimepicker table tr .today.active,
+.datetimepicker table tr .today:hover.active,
+.datetimepicker table tr .today.disabled.active,
+.datetimepicker table tr .today.disabled:hover.active,
+.datetimepicker table tr .today.disabled,
+.datetimepicker table tr .today:hover.disabled,
+.datetimepicker table tr .today.disabled.disabled,
+.datetimepicker table tr .today.disabled:hover.disabled,
+.datetimepicker table tr .today[disabled],
+.datetimepicker table tr .today:hover[disabled],
+.datetimepicker table tr .today.disabled[disabled],
+.datetimepicker table tr .today.disabled:hover[disabled] {
     background-color: #fdf59a;
 }
 
-.datetimepicker table tr td.today:active,
-.datetimepicker table tr td.today:hover:active,
-.datetimepicker table tr td.today.disabled:active,
-.datetimepicker table tr td.today.disabled:hover:active,
-.datetimepicker table tr td.today.active,
-.datetimepicker table tr td.today:hover.active,
-.datetimepicker table tr td.today.disabled.active,
-.datetimepicker table tr td.today.disabled:hover.active {
+.datetimepicker table tr .today:active,
+.datetimepicker table tr .today:hover:active,
+.datetimepicker table tr .today.disabled:active,
+.datetimepicker table tr .today.disabled:hover:active,
+.datetimepicker table tr .today.active,
+.datetimepicker table tr .today:hover.active,
+.datetimepicker table tr .today.disabled.active,
+.datetimepicker table tr .today.disabled:hover.active {
     background-color: #fbf069 \9;
 }
 

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -74,7 +74,8 @@
                   maxValue.setHours(maxValue.getHours(), 59, 59, 999);
                 },
                 minute: function(minValue, maxValue) {
-                  minValue.setHours(minValue.getHours(), minValue.getMinutes(), 0, 0);
+                  var roundedMinutes = minValue.getMinutes() - minValue.getMinutes() % minuteStep;
+                  minValue.setHours(minValue.getHours(), roundedMinutes, 0, 0);
                   maxValue = new Date(minValue.getTime() + (minuteStep-1) * 60000);
                   maxValue.setHours(maxValue.getHours(), maxValue.getMinutes(), 59, 999);
                 }

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -47,6 +47,57 @@
             this[prop] = arguments[0][prop];
           }
         }
+
+        function getMinAndMaxValues(periodView, minuteStep) {
+          var minValue = new Date(),
+              maxValue = new Date(minValue),
+              tzOffsetMs = minValue.getTimezoneOffset() * 60000,
+              handler = { 
+                day: function(minValue, maxValue) {
+                  minValue.setHours(0, 0, 0, 0);
+                  maxValue.setHours(23, 59, 59, 999);
+                },
+                year: function(minValue, maxValue) {
+                  minValue.setMonth(0, 1);
+                  minValue.setHours(0, 0, 0, 0);
+                  maxValue.setMonth(11, 31);
+                  maxValue.setHours(23, 59, 59, 999);
+                },
+                month: function(minValue, maxValue) {
+                  minValue.setDate(1);
+                  minValue.setHours(0, 0, 0, 0);
+                  maxValue.setDate(moment(maxValue).daysInMonth());
+                  maxValue.setHours(23, 59, 59, 999);
+                },
+                hour: function(minValue, maxValue) {
+                  minValue.setHours(minValue.getHours(), 0, 0, 0);
+                  maxValue.setHours(maxValue.getHours(), 59, 59, 999);
+                },
+                minute: function(minValue, maxValue) {
+                  minValue.setHours(minValue.getHours(), minValue.getMinutes(), 0, 0);
+                  maxValue = new Date(minValue.getTime() + (minuteStep-1) * 60000);
+                  maxValue.setHours(maxValue.getHours(), maxValue.getMinutes(), 59, 999);
+                }
+              }[periodView];
+
+          if (!handler) {
+            return;
+          }
+
+          handler(minValue, maxValue);
+
+          return {
+            min: minValue.getTime() - tzOffsetMs,
+            max: maxValue.getTime() - tzOffsetMs
+          };
+        }
+
+        this.isCurrent = function(periodView, periodNames, minuteStep) {
+          var periodFound = periodNames && periodNames.length && periodNames.indexOf(periodView) > -1,
+              minAndMax = periodFound && getMinAndMaxValues(periodView, minuteStep);
+
+          return minAndMax && this.dateValue >= minAndMax.min && this.dateValue <= minAndMax.max;
+        };
       }
 
       var validateConfiguration = function validateConfiguration(configuration) {
@@ -113,7 +164,12 @@
         '           <td colspan="7" >' +
         '              <span    class="{{ data.currentView }}" ' +
         '                       data-ng-repeat="dateObject in data.dates"  ' +
-        '                       data-ng-class="{active: dateObject.active, past: dateObject.past, future: dateObject.future, disabled: !dateObject.selectable}" ' +
+        '                       data-ng-class="{ ' +
+        '                          active: dateObject.active, ' +
+        '                          past: dateObject.past, ' +
+        '                          future: dateObject.future, ' +
+        '                          today: dateObject.isCurrent(data.currentView, showCurrent, configuration.minuteStep), ' +
+        '                          disabled: !dateObject.selectable}" ' +
         '                       data-ng-click="changeView(data.nextView, dateObject, $event)">{{ dateObject.display }}</span> ' +
         '           </td>' +
         '       </tr>' +
@@ -121,7 +177,13 @@
         '           <td data-ng-repeat="dateObject in week.dates" ' +
         '               data-ng-click="changeView(data.nextView, dateObject, $event)"' +
         '               class="day" ' +
-        '               data-ng-class="{active: dateObject.active, past: dateObject.past, future: dateObject.future, disabled: !dateObject.selectable}" >{{ dateObject.display }}</td>' +
+        '               data-ng-class="{' +
+        '                  active: dateObject.active,' +
+        '                  past: dateObject.past,' +
+        '                  future: dateObject.future,' +
+        '                  disabled: !dateObject.selectable,' +
+        '                  today: dateObject.isCurrent(data.currentView, showCurrent, configuration.minuteStep)' +
+        '                }">{{ dateObject.display }}</td>' +
         '       </tr>' +
         '   </tbody>' +
         '</table></div>',
@@ -131,6 +193,9 @@
         },
         replace: true,
         link: function link(scope, element, attrs, ngModelController) {
+
+          scope.showCurrent = attrs.showCurrent ? scope.$parent.$eval(attrs.showCurrent)
+                                                : ['year','month','day','hour','minute'];
 
           var directiveConfig = {};
 
@@ -143,6 +208,8 @@
           angular.extend(configuration, defaultConfig, directiveConfig);
 
           validateConfiguration(configuration);
+
+          scope.configuration = configuration;
 
           var startOfDecade = function startOfDecade(unixDate) {
             var startYear = (parseInt(moment.utc(unixDate).year() / 10, 10) * 10);

--- a/test/configuration/showCurrent.spec.js
+++ b/test/configuration/showCurrent.spec.js
@@ -1,0 +1,80 @@
+/*globals describe, beforeEach, it, expect, module, inject, jQuery, moment, spyOn */
+
+describe('showCurrent', function () {
+  'use strict';
+  var $rootScope, $compile;
+  beforeEach(module('ui.bootstrap.datetimepicker'));
+  beforeEach(inject(function (_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+    $rootScope.date = null;
+  }));
+
+  describe('does not throw exception', function () {
+    it('when showCurrent is missing', function () {
+      $compile('<datetimepicker data-ng-model="date"></datetimepicker>')($rootScope);
+    });
+  });
+
+  describe('has 0 elements with .today class', function () {
+    it('if showCurrent is empty array', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[]" data-datetimepicker-config="{ startView: \'year\', minView: \'year\' }" ></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(0);
+    });
+
+    it('if showCurrent has only day and minView is year', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'day\']" data-datetimepicker-config="{ startView: \'year\', minView: \'year\' }" ></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(0);
+    });
+  });
+
+  describe('has 1 element with .today class', function () {
+    it('if showCurrent has only year and startView is year', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'year\']" data-datetimepicker-config="{ startView: \'year\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(1);
+    });
+
+    it('if showCurrent has only month and startView is month', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'month\']" data-datetimepicker-config="{ startView: \'month\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(1);
+    });
+
+    it('if showCurrent has only day and startView is day', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'day\']" data-datetimepicker-config="{ startView: \'day\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(1);
+    });
+
+    it('if showCurrent has only hour and startView is hour', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'hour\']" data-datetimepicker-config="{ startView: \'hour\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      expect(jQuery('.today', element).length).toEqual(1);
+    });
+
+    it('if showCurrent has only minute and startView is minute', function () {
+
+      var element = $compile('<datetimepicker data-ng-model=\'date\' show-current="[\'minute\']" data-datetimepicker-config="{ startView: \'minute\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+      
+      expect(jQuery('.today', element).length).toEqual(1);
+    });
+  });
+
+});
+


### PR DESCRIPTION
https://github.com/dalelotts/angular-bootstrap-datetimepicker/issues/85

New directive attribute `show-current` is an array of strings-viewnames.
`show-current` default value: `['year','month','day','hour','minute']`

New method - `DateObject.isCurrent(periodView, periodNames, minuteStep)`:
returns `true` if `periodView` given is in `periodNames` and `dateValue` is between start and end of current period.

CSS class `.today` is used to higlight current periods in calendar/timespans.
datetimepicker.css is modified to support every element with `.today` class.

configuration is passed to the scope.