### PR TITLE
support npm + browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "homepage": "http://dalelotts.github.io/angular-bootstrap-datetimepicker",
   "main": "src/js/datetimepicker.js",
   "dependencies": {
-    "bower": "latest"
+    "angular": "^1.3.14",
+    "bower": "latest",
+    "moment": "^2.9.0"
   },
   "devDependencies": {
     "grunt": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "license": "MIT",
   "homepage": "http://dalelotts.github.io/angular-bootstrap-datetimepicker",
   "main": "src/js/datetimepicker.js",
-  "dependencies": {},
+  "dependencies": {
+    "bower": "latest"
+  },
   "devDependencies": {
-    "bower": "latest",
     "grunt": "^0.4.4",
     "grunt-bump": "0.0.16",
     "grunt-complexity": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,16 @@
     "karma-phantomjs-launcher": "^0.1.2",
     "karma-threshold-reporter": "^0.1.12",
     "matchdep": "^0.3.0",
-    "phantomjs": "^1.9.12"
+    "phantomjs": "^1.9.12",
+    "run-browser": "^2.0.2",
+    "tape": "^3.5.0"
   },
   "peerDependencies": {
     "grunt-cli": "0.1.13"
   },
   "scripts": {
     "test": "grunt --verbose",
+    "test-browserify": "run-browser test-browserify.js -b",
     "postinstall": "./node_modules/bower/bin/bower install"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-cli": "0.1.13"
   },
   "scripts": {
-    "test": "grunt --verbose",
+    "test": "npm run test-browserify && grunt --verbose",
     "test-browserify": "run-browser test-browserify.js -b",
     "postinstall": "./node_modules/bower/bin/bower install"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "angular": "^1.3.14",
     "bower": "latest",
-    "moment": "^2.9.0"
+    "moment": "^2.8.4"
   },
   "devDependencies": {
     "grunt": "^0.4.4",

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -18,6 +18,8 @@
   /* istanbul ignore if */
   if (typeof define === 'function' && /* istanbul ignore next */ define.amd) {
     define(['angular', 'moment'], factory); // AMD
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('angular'), require('moment')) // CommonJS
   } else {
     factory(window.angular, window.moment); // Browser global
   }

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -19,7 +19,7 @@
   if (typeof define === 'function' && /* istanbul ignore next */ define.amd) {
     define(['angular', 'moment'], factory); // AMD
   } else if (typeof exports === 'object') {
-    module.exports = factory(require('angular'), require('moment')) // CommonJS
+    module.exports = factory(require('angular'), require('moment')); // CommonJS
   } else {
     factory(window.angular, window.moment); // Browser global
   }

--- a/test-browserify.js
+++ b/test-browserify.js
@@ -1,3 +1,4 @@
+'use strict';
 var angular = require('angular');
 var test = require('tape');
 

--- a/test-browserify.js
+++ b/test-browserify.js
@@ -1,13 +1,13 @@
-var angular = require('angular')
-var test = require('tape')
+var angular = require('angular');
+var test = require('tape');
 
 test("can load module after requiring", function (t) {
   function loadModule () {
-    angular.module("ui.bootstrap.datetimepicker")
+    angular.module("ui.bootstrap.datetimepicker");
   }
 
-  t.throws(loadModule)
-  require('./')
-  t.doesNotThrow(loadModule)
-  t.end()
-})
+  t.throws(loadModule);
+  require('./');
+  t.doesNotThrow(loadModule);
+  t.end();
+});

--- a/test-browserify.js
+++ b/test-browserify.js
@@ -1,0 +1,13 @@
+var angular = require('angular')
+var test = require('tape')
+
+test("can load module after requiring", function (t) {
+  function loadModule () {
+    angular.module("ui.bootstrap.datetimepicker")
+  }
+
+  t.throws(loadModule)
+  require('./')
+  t.doesNotThrow(loadModule)
+  t.end()
+})

--- a/test-browserify.js
+++ b/test-browserify.js
@@ -2,9 +2,9 @@
 var angular = require('angular');
 var test = require('tape');
 
-test("can load module after requiring", function (t) {
+test('can load module after requiring', function (t) {
   function loadModule () {
-    angular.module("ui.bootstrap.datetimepicker");
+    angular.module('ui.bootstrap.datetimepicker');
   }
 
   t.throws(loadModule);


### PR DESCRIPTION
:peach: 

- fixes the https://github.com/dalelotts/angular-bootstrap-datetimepicker/issues/125 bug by moving bower from `devDependencies` to `dependencies`.
- adds CommonJS module definition alongside AMD and global definitions.
- includes a sanity test that can be run with `npm run test-browserify`.

@dalelotts how does this look to you?