### PR TITLE
catch click inside the datetimepicker to prevent from unexpected closing

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -141,6 +141,11 @@
         replace: true,
         link: function link(scope, element, attrs, ngModelController) {
 
+          element.bind('click', function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+          });
+
           var directiveConfig = {};
 
           if (attrs.datetimepickerConfig) {


### PR DESCRIPTION
This fix prevents the datetimepicker dropdown from closing when a user clicks on a non-clickable part of the calendar.