### PR TITLE
Added minDate configuration option.

### DIFF
--- a/demo/demo-controller.js
+++ b/demo/demo-controller.js
@@ -75,7 +75,6 @@ angular.module('demo.demoController', [])
       } 
       var setMinDate = mm+'/'+dd+'/'+yyyy;
       $scope.minDateVar = Date.parse(setMinDate);
-      console.log($scope.minDateVar);
       $scope.configFunction = function configFunction() {
         return {startView: 'month'};
       };

--- a/demo/demo-controller.js
+++ b/demo/demo-controller.js
@@ -25,7 +25,7 @@ angular.module('demo.demoController', [])
       $scope.checkboxOnTimeSet = function () {
         $scope.data.checked = false;
       };
-
+      
       $scope.inputOnTimeSet = function (newDate) {
         // If you are not using jQuery or bootstrap.js,
         // this will throw an error.
@@ -55,7 +55,6 @@ angular.module('demo.demoController', [])
 
       $scope.beforeRender = function ($dates) {
         var index = Math.floor(Math.random() * $dates.length);
-        console.log(index);
         $dates[index].selectable = false;
       };
 
@@ -64,7 +63,19 @@ angular.module('demo.demoController', [])
           startView: 'year'
         }
       };
-
+      var today = new Date();
+      var dd = today.getDate();
+      var mm = today.getMonth()+1;
+      var yyyy = today.getFullYear();
+      if(dd<10) {
+          dd='0'+dd
+      } 
+      if(mm<10) {
+          mm='0'+mm
+      } 
+      var setMinDate = mm+'/'+dd+'/'+yyyy;
+      $scope.minDateVar = Date.parse(setMinDate);
+      console.log($scope.minDateVar);
       $scope.configFunction = function configFunction() {
         return {startView: 'month'};
       };

--- a/demo/index.html
+++ b/demo/index.html
@@ -333,6 +333,36 @@
 
     </div>
 </div>
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Drop-down Datetime with minDate input box</h3>
+        <h4>No formatting</h4>
+
+        <p>Notice that you cannot enter a date with the keyboard.</p>
+
+        <p><code>dropdownSelector: '#dropdown7', minDate: 'mm/dd/yyyy'</code> to toggle the dropdown.</p>
+        {{minDateVar}}
+        <div class="well">
+            <p>Formatted Date: {{ data.dateDropDownInputNoFormatting | date:'medium' }}</p>
+
+            <div class="dropdown">
+                <a class="dropdown-toggle" id="dropdown7" role="button" data-toggle="dropdown" data-target="#"
+                   href="#">
+                    <div class="input-group">
+                        <input type="text" class="form-control" data-ng-model="data.dateDropDownInputNoFormatting">
+                        <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
+                    </div>
+                </a>
+                <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+                    <datetimepicker data-ng-model="data.dateDropDownInputNoFormatting"
+                                    data-datetimepicker-config="{ dropdownSelector: '#dropdown7', minDate:{{minDateVar}} }"></datetimepicker>
+                </ul>
+            </div>
+        </div>
+
+
+    </div>
+</div>
 </div>
 
 

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -95,7 +95,7 @@
         if(parseInt(configuration.minDate.split('/')[1]>31) || parseInt(configuration.minDate.split('/')[1]<0)){
           throw ('minDate format mm/dd/yyyy must have day between 01 and 31');
         }
-        if(parseInt(configuration.minDate.split('/')[0]>12 || parseInt(configuration.minDate.split('/')[0]<1)){
+        if(parseInt(configuration.minDate.split('/')[0]>12) || parseInt(configuration.minDate.split('/')[0]<1)){
           throw ('minDate format mm/dd/yyyy must have month between 01 and 12');
         }
         if (configuration.dropdownSelector !== null && !angular.isString(configuration.dropdownSelector)) {

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -92,7 +92,7 @@
         if(typeof configuration.minDate != 'string'){
           throw ('minDate must be string of the format mm/dd/yyyy');
         }        
-        if(parseInt(configuration.minDate.split('/')[1]>31 || parseInt(configuration.minDate.split('/')[1]<0)){
+        if(parseInt(configuration.minDate.split('/')[1]>31) || parseInt(configuration.minDate.split('/')[1]<0)){
           throw ('minDate format mm/dd/yyyy must have day between 01 and 31');
         }
         if(parseInt(configuration.minDate.split('/')[0]>12 || parseInt(configuration.minDate.split('/')[0]<1)){

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -59,7 +59,7 @@
       }
 
       var validateConfiguration = function validateConfiguration(configuration) {
-        var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector'];
+        var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'minDate'];
 
         for (var prop in configuration) {
           //noinspection JSUnfilteredForInLoop
@@ -92,7 +92,6 @@
         if (configuration.dropdownSelector !== null && !angular.isString(configuration.dropdownSelector)) {
           throw ('dropdownSelector must be a string');
         }
-
         /* istanbul ignore next */
         if (configuration.dropdownSelector !== null && ((typeof jQuery === 'undefined') || (typeof jQuery().dropdown !== 'function'))) {
           $log.error('Please DO NOT specify the dropdownSelector option unless you are using jQuery AND Bootstrap.js. ' +
@@ -311,7 +310,9 @@
 
               return result;
             },
-
+            minDate: function(dateObject){
+              console.log(dateObject);
+            },
             minute: function minute(unixDate) {
               var selectedDate = moment.utc(unixDate).startOf('hour');
               var previousViewDate = moment.utc(selectedDate).startOf('day');
@@ -360,7 +361,7 @@
               scope.onSetTime({newDate: newDate, oldDate: oldDate});
 
               return dataFactory[configuration.startView](unixDate);
-            }
+            },
           };
 
           var getUTCTime = function getUTCTime(modelValue) {
@@ -387,10 +388,20 @@
                   }
                 }
               }
-
+              var mainDates = result.dates || weekDates;              
+              if(configuration.minDate){
+                console.log(configuration.minDate);
+                var date = new Date(parseInt(configuration.minDate));
+                console.log(date);
+                for(i in mainDates){
+                  if(mainDates[i].utcDateValue<date){
+                    mainDates[i].selectable = false
+                  }
+                }
+              }
               scope.beforeRender({
                 $view: result.currentView,
-                $dates: result.dates || weekDates,
+                $dates: mainDates,
                 $leftDate: result.leftDate,
                 $upDate: result.previousViewDate,
                 $rightDate: result.rightDate

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -89,6 +89,15 @@
         if (configuration.minuteStep <= 0 || configuration.minuteStep >= 60) {
           throw ('minuteStep must be greater than zero and less than 60');
         }
+        if(typeof configuration.minDate != 'string'){
+          throw ('minDate must be string of the format mm/dd/yyyy');
+        }        
+        if(parseInt(configuration.minDate.split('/')[1]>31 || parseInt(configuration.minDate.split('/')[1]<0)){
+          throw ('minDate format mm/dd/yyyy must have day between 01 and 31');
+        }
+        if(parseInt(configuration.minDate.split('/')[0]>12 || parseInt(configuration.minDate.split('/')[0]<1)){
+          throw ('minDate format mm/dd/yyyy must have month between 01 and 12');
+        }
         if (configuration.dropdownSelector !== null && !angular.isString(configuration.dropdownSelector)) {
           throw ('dropdownSelector must be a string');
         }


### PR DESCRIPTION
I've added a `minDate` config option as follows:

`html`

    datetimepicker data-ng-model="data.dateDropDownInputNoFormatting"
                                    data-datetimepicker-config="{ dropdownSelector: '#dropdown7', minDate:{{minDateVar}} }"></datetimepicker>

js:

`demo-controller.js`

    var today = new Date();
    var dd = today.getDate();
    var mm = today.getMonth()+1;
    var yyyy = today.getFullYear();
    if(dd<10) {
        dd='0'+dd
    } 
    if(mm<10) {
        mm='0'+mm
    } 
    var setMinDate = mm+'/'+dd+'/'+yyyy;
    $scope.minDateVar = Date.parse(setMinDate);

`datetimepicker.js`

    var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'minDate'];

    ...

    var mainDates = result.dates || weekDates;
    if (configuration.minDate) {
        console.log(configuration.minDate);
        var date = new Date(parseInt(configuration.minDate));
        console.log(date);
        for (i in mainDates) {
            if (mainDates[i].utcDateValue < date) {
                mainDates[i].selectable = false
            }
        }
    }
    scope.beforeRender({
        $view: result.currentView,
        $dates: mainDates,
        $leftDate: result.leftDate,
        $upDate: result.previousViewDate,
        $rightDate: result.rightDate
    });
