### PR TITLE
feat: add the ability to manipulate UTC dates only

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -329,12 +329,37 @@
                 </ul>
             </div>
         </div>
+    </div>
+</div>
 
+<div class="row">
+    <div class="col-sm-6">
+        <h3>Drop-down Datetime with input box</h3>
+        <p>Notice that you cannot enter a date with the keyboard.</p>
 
+        <p>
+            <code>utcOnly: true</code> and <code>dropdownSelector: '#dropdown7'</code> to toggle the dropdown.
+        </p>
+
+        <div class="well">
+            <p>Formatted Date (UTC): {{ data.dateDropDownInputNoFormatting | date:'medium':'UTC' }}</p>
+
+            <div class="dropdown">
+                <a class="dropdown-toggle" id="dropdown7" role="button" data-toggle="dropdown" data-target="#"
+                   href="#">
+                    <div class="input-group">
+                        <input type="text" class="form-control" data-ng-model="data.dateDropDownInputNoFormatting">
+                        <span class="input-group-addon"><i class="glyphicon glyphicon-calendar"></i></span>
+                    </div>
+                </a>
+                <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+                    <datetimepicker data-ng-model="data.dateDropDownInputNoFormatting"
+                                    data-datetimepicker-config="{ dropdownSelector: '#dropdown7', utcOnly: true }"></datetimepicker>
+                </ul>
+            </div>
+        </div>
     </div>
 </div>
 </div>
-
-
 </body>
 </html>

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -31,7 +31,8 @@
       dropdownSelector: null,
       minuteStep: 5,
       minView: 'minute',
-      startView: 'day'
+      startView: 'day',
+      utcOnly: false
     })
     .directive('datetimepicker', ['$log', 'dateTimePickerConfig', function datetimepickerDirective($log, defaultConfig) {
 
@@ -59,7 +60,7 @@
       }
 
       var validateConfiguration = function validateConfiguration(configuration) {
-        var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector'];
+        var validOptions = ['startView', 'minView', 'minuteStep', 'dropdownSelector', 'utcOnly'];
 
         for (var prop in configuration) {
           //noinspection JSUnfilteredForInLoop
@@ -347,8 +348,11 @@
             },
 
             setTime: function setTime(unixDate) {
-              var tempDate = new Date(unixDate);
-              var newDate = new Date(tempDate.getTime() + (tempDate.getTimezoneOffset() * 60000));
+              var newDate = new Date(unixDate);
+              if (!configuration.utcOnly) {
+                var tempDate = new Date(unixDate);
+                newDate = new Date(tempDate.getTime() + (tempDate.getTimezoneOffset() * 60000));
+              }
 
               var oldDate = ngModelController.$modelValue;
               ngModelController.$setViewValue(newDate);


### PR DESCRIPTION
With this option set to true, the time selected by the user is not locale but UTC.

For example: selecting 13h with a timezone Europe/London (+1h) will not set date to 12h+1 but to 13h+1

I add an example at the end of the demo.html file