### PR TITLE
Allow 'npm install' on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "test": "npm run test-browserify && gulp",
     "test-browserify": "run-browser test/commonjs/browserify.test.js -b",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix for postinstall script