### PR TITLE
Sass support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,16 +11,15 @@ var lodash = require('lodash');
 var paths = require('./paths');
 var plato = require('plato');
 var Server = require('karma').Server;
+var sass = require('gulp-sass');
 
 gulp.task('complexity', function (done) {
-
   var callback = function () {
     done();
   };
 
   plato.inspect(paths.lint, 'complexity', {title: 'prerender', recurse: true}, callback);
 });
-
 
 gulp.task('csslint', function () {
   return gulp.src(paths.css)
@@ -84,4 +83,14 @@ gulp.task('jscs', function () {
     .pipe(jscs('.jscsrc'));
 });
 
-gulp.task('default', ['jscs', 'lint', 'csslint', 'complexity', 'test']);
+gulp.task('sass', function () {
+  gulp.src(paths.sass)
+    .pipe(sass().on('error', sass.logError))
+    .pipe(gulp.dest('./src/css'));
+});
+
+gulp.task('sass:watch', function () {
+  gulp.watch(paths.sass, ['sass']);
+});
+
+gulp.task('default', ['sass','jscs', 'lint', 'csslint', 'complexity', 'test']);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-csslint": "^0.2.0",
     "gulp-jscs": "^3.0.0",
     "gulp-jshint": "^1.11.2",
+    "gulp-sass": "^2.0.4",
     "jquery": "^2.1.4",
     "jshint": "^2.6.0",
     "jshint-stylish": "^2.0.1",

--- a/paths.js
+++ b/paths.js
@@ -14,12 +14,14 @@ var demoFiles = ['demo/**/*.js'];
 var miscFiles = ['GruntFile.js', 'gulpfile.js', 'karma.conf.js', 'paths.js'];
 var sourceFiles = ['src/**/*.js'];
 var testFiles = ['test/**/*.spec.js'];
+var sassFiles = ['src/sass/*.scss'];
 
 module.exports = {
   all: modules.concat(sourceFiles).concat(testFiles).concat(demoFiles),
   app: sourceFiles,
   bump: bumpFiles.concat(cssFiles),
   css: cssFiles,
+  sass : sassFiles,
   lint: miscFiles.concat(sourceFiles).concat(testFiles).concat(miscFiles),
   src: sourceFiles,
   test: testFiles

--- a/src/css/datetimepicker.css
+++ b/src/css/datetimepicker.css
@@ -1,5 +1,5 @@
 /**
- * @license abd  version: 0.3.14
+ * @license angular-bootstrap-datetimepicker version: 0.3.14
  * Copyright 2013-2015 Knight Rider Consulting, Inc. http://www.knightrider.com
  * License: MIT
  */

--- a/src/css/datetimepicker.css
+++ b/src/css/datetimepicker.css
@@ -1,90 +1,78 @@
 /**
- * @license angular-bootstrap-datetimepicker  version: 0.3.14
+ * @license abd  version: 0.3.14
  * Copyright 2013-2015 Knight Rider Consulting, Inc. http://www.knightrider.com
  * License: MIT
  */
-
 .datetimepicker {
-    margin-top: 1px;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
-    border-radius: 4px;
-    direction: ltr;
-    width: 320px;
-    display: block;
-}
+  margin-top: 1px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  direction: ltr;
+  width: 320px;
+  display: block; }
 
 .datetimepicker.datetimepicker-rtl {
-    direction: rtl;
-}
+  direction: rtl; }
 
 .datetimepicker.datetimepicker-rtl table tr td span {
-    float: right;
-}
+  float: right; }
 
 .datetimepicker > div {
-    display: none;
-}
+  display: none; }
 
 .datetimepicker .hour,
 .datetimepicker .minute {
-    margin: 0;
-    height: 34px;
-    line-height: 34px;
-    width: 25%;
-}
+  margin: 0;
+  height: 34px;
+  line-height: 34px;
+  width: 25%; }
 
 .datetimepicker table {
-    margin: 0;
-}
+  margin: 0; }
 
 .datetimepicker .table td,
 .datetimepicker .table th {
-    text-align: center;
-    height: 20px;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
-    border-radius: 4px;
-    border: none;
-}
+  text-align: center;
+  height: 20px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  border: none; }
 
 .datetimepicker .minute:hover,
 .datetimepicker .hour:hover,
 .datetimepicker .day:hover {
-    background: #eeeeee;
-    cursor: pointer;
-}
+  background: #eeeeee;
+  cursor: pointer; }
 
 .datetimepicker .past,
 .datetimepicker .future {
-    color: #999999;
-}
+  color: #999999; }
 
 .datetimepicker td.disabled,
 .datetimepicker td.disabled:hover {
-    background: none;
-    color: #999999;
-    cursor: default;
-}
+  background: none;
+  color: #999999;
+  cursor: default; }
 
 .datetimepicker td.active,
 .datetimepicker td.active:hover,
 .datetimepicker td.active.disabled,
 .datetimepicker td.active.disabled:hover {
-    background-color: #006dcc;
-    background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -ms-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
-    background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-    background-image: linear-gradient(top, #0088cc, #0044cc);
-    background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
-    border-color: #0044cc #0044cc #002a80;
-    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-    color: #fff;
-    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-}
+  background-color: #006dcc;
+  background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -ms-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
+  background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -o-linear-gradient(top, #0088cc, #0044cc);
+  background-image: linear-gradient(top, #0088cc, #0044cc);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
+  border-color: #0088cc #0044cc #002a80;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25); }
 
 .datetimepicker td.active:hover,
 .datetimepicker td.active:hover:hover,
@@ -106,51 +94,46 @@
 .datetimepicker td.active:hover[disabled],
 .datetimepicker td.active.disabled[disabled],
 .datetimepicker td.active.disabled:hover[disabled] {
-    background-color: #0044cc;
-}
+  background-color: #0044cc; }
 
 .datetimepicker span {
-    display: block;
-    width: 23%;
-    height: 54px;
-    line-height: 54px;
-    float: left;
-    margin: 1%;
-    cursor: pointer;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
-    border-radius: 4px;
-}
+  display: block;
+  width: 23%;
+  height: 54px;
+  line-height: 54px;
+  float: left;
+  margin: 1%;
+  cursor: pointer;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px; }
 
 .datetimepicker span:hover {
-    background: #eeeeee;
-}
+  background: #eeeeee; }
 
 .datetimepicker span.disabled,
 .datetimepicker span.disabled:hover {
-    background: none;
-    color: #999999;
-    cursor: default;
-}
+  background: none;
+  color: #999999;
+  cursor: default; }
 
 .datetimepicker span.active,
 .datetimepicker span.active:hover,
 .datetimepicker span.active.disabled,
 .datetimepicker span.active.disabled:hover {
-    background-color: #006dcc;
-    background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -ms-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
-    background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
-    background-image: -o-linear-gradient(top, #0088cc, #0044cc);
-    background-image: linear-gradient(top, #0088cc, #0044cc);
-    background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
-    border-color: #0044cc #0044cc #002a80;
-    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-    color: #fff;
-    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-}
+  background-color: #006dcc;
+  background-image: -moz-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -ms-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0044cc));
+  background-image: -webkit-linear-gradient(top, #0088cc, #0044cc);
+  background-image: -o-linear-gradient(top, #0088cc, #0044cc);
+  background-image: linear-gradient(top, #0088cc, #0044cc);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
+  border-color: #0088cc #0044cc #002a80;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25); }
 
 .datetimepicker span.active:hover,
 .datetimepicker span.active:hover:hover,
@@ -172,20 +155,16 @@
 .datetimepicker span.active:hover[disabled],
 .datetimepicker span.active.disabled[disabled],
 .datetimepicker span.active.disabled:hover[disabled] {
-    background-color: #0044cc;
-}
+  background-color: #0044cc; }
 
 .datetimepicker span.past,
 .datetimepicker span.future {
-    color: #999999;
-}
+  color: #999999; }
 
 .datetimepicker thead tr:first-child th,
 .datetimepicker tfoot tr:first-child th {
-    cursor: pointer;
-}
+  cursor: pointer; }
 
 .datetimepicker thead tr:first-child th:hover,
 .datetimepicker tfoot tr:first-child th:hover {
-    background: #eeeeee;
-}
+  background: #eeeeee; }

--- a/src/sass/_core.scss
+++ b/src/sass/_core.scss
@@ -1,5 +1,5 @@
 /**
- * @license abd  version: 0.3.14
+ * @license angular-bootstrap-datetimepicker  version: 0.3.14
  * Copyright 2013-2015 Knight Rider Consulting, Inc. http://www.knightrider.com
  * License: MIT
  */

--- a/src/sass/_core.scss
+++ b/src/sass/_core.scss
@@ -1,0 +1,191 @@
+/**
+ * @license abd  version: 0.3.14
+ * Copyright 2013-2015 Knight Rider Consulting, Inc. http://www.knightrider.com
+ * License: MIT
+ */
+
+.datetimepicker {
+    margin-top: 1px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    direction: ltr;
+    width: 320px;
+    display: block;
+}
+
+.datetimepicker.datetimepicker-rtl {
+    direction: rtl;
+}
+
+.datetimepicker.datetimepicker-rtl table tr td span {
+    float: right;
+}
+
+.datetimepicker > div {
+    display: none;
+}
+
+.datetimepicker .hour,
+.datetimepicker .minute {
+    margin: 0;
+    height: 34px;
+    line-height: 34px;
+    width: 25%;
+}
+
+.datetimepicker table {
+    margin: 0;
+}
+
+.datetimepicker .table td,
+.datetimepicker .table th {
+    text-align: center;
+    height: 20px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    border: none;
+}
+
+.datetimepicker .minute:hover,
+.datetimepicker .hour:hover,
+.datetimepicker .day:hover {
+    background: $abd-color-hover;
+    cursor: pointer;
+}
+
+.datetimepicker .past,
+.datetimepicker .future {
+    color: $abd-color-disabled;
+}
+
+.datetimepicker td.disabled,
+.datetimepicker td.disabled:hover {
+    background: none;
+    color: $abd-color-disabled;
+    cursor: default;
+}
+
+.datetimepicker td.active,
+.datetimepicker td.active:hover,
+.datetimepicker td.active.disabled,
+.datetimepicker td.active.disabled:hover {
+    background-color: $abd-background-color;
+    background-image: -moz-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -ms-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from($abd-background-color-start), to($abd-background-color-stop));
+    background-image: -webkit-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -o-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
+    border-color: $abd-background-color-start $abd-background-color-stop #002a80;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+    color: #fff;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+
+.datetimepicker td.active:hover,
+.datetimepicker td.active:hover:hover,
+.datetimepicker td.active.disabled:hover,
+.datetimepicker td.active.disabled:hover:hover,
+.datetimepicker td.active:active,
+.datetimepicker td.active:hover:active,
+.datetimepicker td.active.disabled:active,
+.datetimepicker td.active.disabled:hover:active,
+.datetimepicker td.active.active,
+.datetimepicker td.active:hover.active,
+.datetimepicker td.active.disabled.active,
+.datetimepicker td.active.disabled:hover.active,
+.datetimepicker td.active.disabled,
+.datetimepicker td.active:hover.disabled,
+.datetimepicker td.active.disabled.disabled,
+.datetimepicker td.active.disabled:hover.disabled,
+.datetimepicker td.active[disabled],
+.datetimepicker td.active:hover[disabled],
+.datetimepicker td.active.disabled[disabled],
+.datetimepicker td.active.disabled:hover[disabled] {
+    background-color: $abd-background-color-stop;
+}
+
+.datetimepicker span {
+    display: block;
+    width: 23%;
+    height: 54px;
+    line-height: 54px;
+    float: left;
+    margin: 1%;
+    cursor: pointer;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+}
+
+.datetimepicker span:hover {
+    background: $abd-color-hover;
+}
+
+.datetimepicker span.disabled,
+.datetimepicker span.disabled:hover {
+    background: none;
+    color: $abd-color-disabled;
+    cursor: default;
+}
+
+.datetimepicker span.active,
+.datetimepicker span.active:hover,
+.datetimepicker span.active.disabled,
+.datetimepicker span.active.disabled:hover {
+    background-color: $abd-background-color;
+    background-image: -moz-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -ms-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from($abd-background-color-start), to($abd-background-color-stop));
+    background-image: -webkit-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: -o-linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-image: linear-gradient(top, $abd-background-color-start, $abd-background-color-stop);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#0088cc', endColorstr='#0044cc', GradientType=0);
+    border-color: $abd-background-color-start $abd-background-color-stop #002a80;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+    color: #fff;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+
+.datetimepicker span.active:hover,
+.datetimepicker span.active:hover:hover,
+.datetimepicker span.active.disabled:hover,
+.datetimepicker span.active.disabled:hover:hover,
+.datetimepicker span.active:active,
+.datetimepicker span.active:hover:active,
+.datetimepicker span.active.disabled:active,
+.datetimepicker span.active.disabled:hover:active,
+.datetimepicker span.active.active,
+.datetimepicker span.active:hover.active,
+.datetimepicker span.active.disabled.active,
+.datetimepicker span.active.disabled:hover.active,
+.datetimepicker span.active.disabled,
+.datetimepicker span.active:hover.disabled,
+.datetimepicker span.active.disabled.disabled,
+.datetimepicker span.active.disabled:hover.disabled,
+.datetimepicker span.active[disabled],
+.datetimepicker span.active:hover[disabled],
+.datetimepicker span.active.disabled[disabled],
+.datetimepicker span.active.disabled:hover[disabled] {
+    background-color: $abd-background-color-stop;
+}
+
+.datetimepicker span.past,
+.datetimepicker span.future {
+    color: $abd-color-disabled;
+}
+
+.datetimepicker thead tr:first-child th,
+.datetimepicker tfoot tr:first-child th {
+    cursor: pointer;
+}
+
+.datetimepicker thead tr:first-child th:hover,
+.datetimepicker tfoot tr:first-child th:hover {
+    background: $abd-color-hover;
+}

--- a/src/sass/_datetimepicker.scss
+++ b/src/sass/_datetimepicker.scss
@@ -1,0 +1,2 @@
+@import "variables";
+@import "core";

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -1,0 +1,5 @@
+$abd-color-disabled : #999999 !default;
+$abd-color-hover : #eeeeee !default;
+$abd-background-color : #006dcc !default;
+$abd-background-color-start : #0088cc !default;
+$abd-background-color-stop : #0044cc !default;

--- a/src/sass/datetimepicker.scss
+++ b/src/sass/datetimepicker.scss
@@ -1,0 +1,2 @@
+@import "variables";
+@import "core";

--- a/src/sass/datetimepicker.scss
+++ b/src/sass/datetimepicker.scss
@@ -1,2 +1,1 @@
-@import "variables";
-@import "core";
+@import "datetimepicker"


### PR DESCRIPTION
#Sass support

This PR adds Sass support: it has a `sass` folder with the sass files, and a gulp task creates a css file inside the css folder. 

The `sass` folder contains:
- `datetimepicker.scss` : used to generated the old css file 
- `_datetimepicker.scss` : the partial than can be used for importing the style into a custom sass file. It imports the other partials in the folder (`_variables.scss` and `_core.scss`)

