### PR TITLE
Implement highlighted today element in calendar

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -67,6 +67,11 @@
       'zh-tw': {prev: '上一頁', next: '下一頁'}
     })
     .directive('datetimepicker', ['$log', 'dateTimePickerConfig', 'srDictionary', function datetimepickerDirective($log, defaultConfig, srDictionary) {
+      function isToday(d) {
+        var today = moment().local().format('YYYY-MM-DD');
+        var param = moment(d).local().format('YYYY-MM-DD');
+        return today === param;
+      }
 
       function DateObject() {
 
@@ -90,6 +95,8 @@
             this[prop] = arguments[0][prop];
           }
         }
+
+        this['isToday'] = isToday(this.localDateValue());
       }
 
       var validateConfiguration = function validateConfiguration(configuration) {
@@ -196,7 +203,7 @@
         '           <td data-ng-repeat="dateObject in week.dates" ' +
         '               data-ng-click="changeView(data.nextView, dateObject, $event)"' +
         '               class="day" ' +
-        '               data-ng-class="{active: dateObject.active, past: dateObject.past, future: dateObject.future, disabled: !dateObject.selectable}" >{{ dateObject.display }}</td>' +
+        '               data-ng-class="{today: dateObject.isToday, active: dateObject.active, past: dateObject.past, future: dateObject.future, disabled: !dateObject.selectable}" >{{ dateObject.display }}</td>' +
         '       </tr>' +
         '   </tbody>' +
         '</table></div>',

--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -60,6 +60,14 @@
     text-shadow: 0 -1px 0 rgba(0, 0, 0, .25);
   }
 
+  .today,
+  .today:hover,
+  .today.disabled,
+  .today.disabled:hover {
+    background-color: $abdtp-today-background-color;
+    color: $abdtp-today-color;
+  }
+
   // scss-lint:disable QualifyingElement
   .active:hover,
   .active:hover:hover,

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -5,6 +5,8 @@ $abdtp-active-border-bottom-color:  #002a80 !default;
 $abdtp-background-color-end:        #04c !default;
 $abdtp-background-color-start:      #08c !default;
 $abdtp-background-color:            #006dcc !default;
+$abdtp-today-color:                 #c00 !default;
+$abdtp-today-background-color:      #006dcc !default;
 $abdtp-color-disabled:              #ebebeb !default;
 $abdtp-color-hover:                 #eee !default;
 $abdtp-color-past-future:           #999 !default;


### PR DESCRIPTION
- Background or text color can be overriden via scss labels, default is #c00 for the text.
- Fixes #202