### PR TITLE
Fix leaking listeners and DOM elements.

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -433,6 +433,12 @@
             scope.changeView(configuration.startView, new DateObject({utcDateValue: getUTCTime(ngModelController.$viewValue)}));
           };
 
+          scope.$on('$destroy', function(){
+            dataFactory = null;
+            scope.changeView = null;
+          });
+
+
           if (configuration.configureOn) {
             scope.$on(configuration.configureOn, function () {
               configuration = configure();


### PR DESCRIPTION
Hey. 

This is a brute force fix for leaking listeners and DOM elements. Currently scope parameter of link function is being passed via closure to listener function and to functions in data factory. As always in closures, this means that browser will keep whole context of the linking function, so here it will include element as well. It made proper garbage collection not possible (profiled on Chrome).

It can be fixed cleaner e.g. by using local variables in linking function and then passing those via closure or by restructuring the code a bit. Please excuse that I did not do it in the first place, but I do not know the project and had to quickly plug in this component. 

I am pushing this PR just to provide a quick fix - in case anybody else would like to get rid of performance issues. If you decide to solve the problem in another way, please just ignore this PR.

Cheers!
Bartek 