### PR TITLE
Add support to moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-threshold-reporter": "^0.1.12",
     "lodash": "^4.5.0",
     "matchdep": "^1.0.1",
+    "moment-timezone": "^0.5.0",
     "phantomjs-prebuilt": "^2.1.4",
     "plato": "^1.5.0",
     "run-browser": "^2.0.2",

--- a/paths.js
+++ b/paths.js
@@ -4,6 +4,7 @@ var modules = [
   'node_modules/jquery/dist/jquery.js',
   'node_modules/moment/moment.js',
   'node_modules/moment/locale/*.js',
+  'node_modules/moment-timezone/builds/moment-timezone-with-data.js',
   'node_modules/bootstrap/dist/js/bootstrap.js',
   'node_modules/angular/angular.js',
   'node_modules/angular-mocks/angular-mocks.js'

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -315,13 +315,13 @@
             // No additional work needed
             break;
           case 'moment':
-            newDate = moment(newDate);
+            newDate = moment([tempDate.getUTCFullYear(), tempDate.getUTCMonth(), tempDate.getUTCDate(), tempDate.getUTCHours(), tempDate.getUTCMinutes(), tempDate.getUTCSeconds(), tempDate.getUTCMilliseconds()]);
             break;
           case 'milliseconds':
             newDate = milliseconds;
             break;
           default: // It is assumed that the modelType is a formatting string.
-            newDate = moment(newDate).format(configuration.modelType);
+            newDate = moment([tempDate.getUTCFullYear(), tempDate.getUTCMonth(), tempDate.getUTCDate(), tempDate.getUTCHours(), tempDate.getUTCMinutes(), tempDate.getUTCSeconds(), tempDate.getUTCMilliseconds()]).format(configuration.modelType);
         }
 
         var oldDate = ngModelController.$modelValue;

--- a/test/model/modelType.spec.js
+++ b/test/model/modelType.spec.js
@@ -18,6 +18,7 @@ describe('modelType', function () {
     $compile = _$compile_;
     $rootScope = _$rootScope_;
     $rootScope.date = null;
+    moment.tz.setDefault(null);
   }));
 
   describe('throws exception', function () {
@@ -142,6 +143,32 @@ describe('modelType', function () {
 
       expect(moment('1999-01-01').isSame($rootScope.date)).toBeTruthy();
     });
+    it('returns a moment with correct time zone', function () {
+
+      $rootScope.date = 1132185600000;   // '2005-11-17'
+      moment.tz.setDefault('America/Los_Angeles');
+
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ modelType: \'moment\', startView: \'year\', minView: \'year\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      var selectedElement = jQuery(jQuery('.year', element)[0]);
+      selectedElement.trigger('click');
+
+      expect(moment('1999-01-01T00:00:00-08:00').isSame($rootScope.date)).toBeTruthy();
+    });
+    it('returns a moment with correct time zone', function () {
+
+      $rootScope.date = 1132185600000;   // '2005-11-17'
+      moment.tz.setDefault('America/New_York');
+
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ modelType: \'moment\', startView: \'year\', minView: \'year\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      var selectedElement = jQuery(jQuery('.year', element)[0]);
+      selectedElement.trigger('click');
+
+      expect(moment('1999-01-01T00:00:00-05:00').isSame($rootScope.date)).toBeTruthy();
+    });
     it('throws an exception if invalid date string is in the model', function () {
 
       $rootScope.date = 'invalid-date';
@@ -262,6 +289,32 @@ describe('modelType', function () {
       selectedElement.trigger('click');
 
       expect($rootScope.date).toBe('gibb5ri012');
+    });
+    it('returns formatted string in correct time zone', function () {
+
+      $rootScope.date = moment('2005-11-17').toDate();
+      moment.tz.setDefault('America/Los_Angeles');
+
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ modelType: \'MM-DD-YYYY Z\', startView: \'year\', minView: \'year\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      var selectedElement = jQuery(jQuery('.year', element)[0]);
+      selectedElement.trigger('click');
+
+      expect($rootScope.date).toBe('01-01-1999 -08:00');
+    });
+    it('returns formatted string in correct time zone', function () {
+
+      $rootScope.date = moment('2005-11-17').toDate();
+      moment.tz.setDefault('America/New_York');
+
+      var element = $compile('<datetimepicker data-ng-model="date" data-datetimepicker-config="{ modelType: \'MM-DD-YYYY Z\', startView: \'year\', minView: \'year\' }"></datetimepicker>')($rootScope);
+      $rootScope.$digest();
+
+      var selectedElement = jQuery(jQuery('.year', element)[0]);
+      selectedElement.trigger('click');
+
+      expect($rootScope.date).toBe('01-01-1999 -05:00');
     });
     it('throws an exception if numeric string is in the model', function () {
 


### PR DESCRIPTION
Currently moment value is initialized from Date object which is always in local timezone. With this change moment value is initialized with array constructor which uses timezone currently set for moment (http://momentjs.com/docs/#/parsing/array/). By default timezone is local (i.e. functionality is same as before), but may be changed with moment-timezone extension (http://momentjs.com/timezone/docs/#/using-timezones/default-timezone/).