### PR TITLE
make sure localDateValue() takes local daylight savings into account

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -420,7 +420,13 @@
     }
 
     function DateObject () {
+      var constructorObject = arguments[0]
       var tempDate = new Date()
+
+      if (constructorObject && constructorObject.utcDateValue) {
+        tempDate.setTime(constructorObject.utcDateValue)
+      }
+
       var localOffset = tempDate.getTimezoneOffset() * 60000
 
       this.utcDateValue = tempDate.getTime()
@@ -431,8 +437,6 @@
       }
 
       var validProperties = ['active', 'current', 'display', 'future', 'past', 'selectable', 'utcDateValue']
-
-      var constructorObject = arguments[0]
 
       Object.keys(constructorObject).filter(function (key) {
         return validProperties.indexOf(key) >= 0

--- a/test/configuration/beforeRender.spec.js
+++ b/test/configuration/beforeRender.spec.js
@@ -72,14 +72,16 @@ describe('beforeRender', function () {
     it('in day view $dates parameter contains 42 members', function () {
       $rootScope.date = moment('2014-01-01T00:00:00.000').toDate()
 
-      var offset = new Date().getTimezoneOffset() * 60000
+      var offsetDate = new Date()
 
       $rootScope.beforeRender = function (dates) {
         expect(dates.length).toBe(42)
         expect(dates[0].utcDateValue).toBe(1388275200000)
-        expect(dates[0].localDateValue()).toBe(1388275200000 + offset)
+        offsetDate.setTime(dates[0].utcDateValue)
+        expect(dates[0].localDateValue()).toBe(1388275200000 + (offsetDate.getTimezoneOffset() * 60000))
         expect(dates[11].utcDateValue).toBe(1389225600000)
-        expect(dates[11].localDateValue()).toBe(1389225600000 + offset)
+        offsetDate.setTime(dates[11].utcDateValue)
+        expect(dates[11].localDateValue()).toBe(1389225600000 + (offsetDate.getTimezoneOffset() * 60000))
       }
 
       spyOn($rootScope, 'beforeRender').and.callThrough()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
call to localDateValue() returns the wrong value for some days if there is a daylight saving change in this month as it only looks at the timezoneOffset for today instead of the actual day

**What is the new behavior (if this is a feature change)?**
it uses the timezoneOffset of the specific day to calculate the localDateValue


**Does this PR introduce a breaking change?**
no


**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

**Other information**:

