### PR TITLE
fix invalid date when manually typing date

### DIFF
--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -394,6 +394,7 @@
       function getUTCTime (modelValue) {
         var tempDate = new Date()
         if (modelValue && modelValue.lenght > 4) {
+
           var tempMoment = getMoment(modelValue)
           if (tempMoment.isValid()) {
             tempDate = tempMoment.toDate()

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -393,7 +393,7 @@
 
       function getUTCTime (modelValue) {
         var tempDate = new Date()
-        if (modelValue) {
+        if (modelValue && modelValue.lenght > 4) {
           var tempMoment = getMoment(modelValue)
           if (tempMoment.isValid()) {
             tempDate = tempMoment.toDate()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix to error thrown when manually typing date

**What is the current behavior? (You can also link to an open issue here)**
For example: 10/0 (throws) & 10-0 (throws)


**What is the new behavior (if this is a feature change)?**
From now the error only is thrown when the input value length is greater than 4


**Does this PR introduce a breaking change?**
No, it doesn't.


**Please check if the PR fulfills these requirements**
- [x] This PR is against the `develop` branch. (Please do not submit PR's to the master branch)
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
The changes I've made it's only a check if input value is valid.
