### PR TITLE
Fix invalid date

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Native AngularJS datetime picker directive styled by Twitter Bootstrap 3
 
 [Home / demo page](http://dalelotts.github.io/angular-bootstrap-datetimepicker/)
 
+## Support the project
+I know this is a tiny directive but many people use it in production (high 5 to all of us) - if you happen to use this directive please click the star button (at the top of the page) - it means a lot to all the contributors.
+
 ## Upgrading from 0.4.0 or earlier
 
 The template used by this directive has been separated from the directive to allow the developer to override

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -394,6 +394,7 @@
       function getUTCTime (modelValue) {
         var tempDate = new Date()
         if (modelValue && modelValue.lenght > 4) {
+
           var tempMoment = getMoment(modelValue)
           if (tempMoment.isValid()) {
             tempDate = tempMoment.toDate()

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -393,8 +393,7 @@
 
       function getUTCTime (modelValue) {
         var tempDate = new Date()
-        if (modelValue && modelValue.lenght > 4) {
-
+        if (modelValue && modelValue.length > 4) {
           var tempMoment = getMoment(modelValue)
           if (tempMoment.isValid()) {
             tempDate = tempMoment.toDate()

--- a/src/js/datetimepicker.js
+++ b/src/js/datetimepicker.js
@@ -393,7 +393,7 @@
 
       function getUTCTime (modelValue) {
         var tempDate = new Date()
-        if (modelValue) {
+        if (modelValue && modelValue.lenght > 4) {
           var tempMoment = getMoment(modelValue)
           if (tempMoment.isValid()) {
             tempDate = tempMoment.toDate()

--- a/test/configuration/onSetTime.spec.js
+++ b/test/configuration/onSetTime.spec.js
@@ -77,5 +77,13 @@ describe('onSetTime', function () {
       expect($rootScope.setTimeFunction).toHaveBeenCalled()
     })
   })
+
+  describe('Manually typing date', function () {
+    it('if date value is manually typed should not thrown an error when the date value is not completed', function () {
+      $rootScope.setManuallyDateFunction = function (modelValue) {
+        expect(modelValue).toEqual(moment('20-0').isValid() === false)
+      }
+    })
+  })
 })
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix to error thrown when manually typing date


**What is the current behavior? (You can also link to an open issue here)**
For example: 10/0 (throws) & 10-0 (throws)


**What is the new behavior (if this is a feature change)?**
From now the error only is thrown when the input value length is greater than 4


**Does this PR introduce a breaking change?**
No, it doesn't.


**Please check if the PR fulfills these requirements**
- [x] This PR is against the `develop` branch. (Please do not submit PR's to the master branch)
- [x] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
The changes I've made it's only a check if input value is valid.