### PR TITLE
Fix ReferenceError in DlDateTimePickerComponent._handleKeyDown

### DIFF
--- a/src/lib/dl-date-time-picker/dl-date-time-picker.component.ts
+++ b/src/lib/dl-date-time-picker/dl-date-time-picker.component.ts
@@ -415,7 +415,7 @@ export class DlDateTimePickerComponent<D> implements OnChanges, OnInit, ControlV
 
       this.focusActiveCell();
       // Prevent unexpected default actions such as form submission.
-      event.preventDefault();
+      $event.preventDefault();
     }
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix


**What is the current behavior? (You can also link to an open issue here)**
On key press, a Javascript ReferenceError is triggered due to an undefined variable


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [-] This PR is against the `develop` branch. (Please do not submit PR's to the master branch)
- [X] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [-] Tests for the changes have been added (for bug fixes / features)
- [-] Docs have been added / updated (for bug fixes / features)

**Other information**:
Targeting master as develop is very out of date