### PR TITLE
docs(readme): correct package name for v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Native Angular (8+) datetime picker component styled by Twitter Bootstrap 4.
 
 Use install version 3.1.0
 
-`npm install angularjs-bootstrap-datetimepicker@3.1.0`
+`npm install angular-bootstrap-datetimepicker@3.1.0`
 
 ## On Angular 1.x?
 


### PR DESCRIPTION
this requirement `angularjs-bootstrap-datetimepicker@3.1.0` [don't exists](https://www.npmjs.com/package/angularjs-bootstrap-datetimepicker)

So I updated to the other package where 3.1.0 exist

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix of readme

**What is the current behavior? (You can also link to an open issue here)**

----

**What is the new behavior (if this is a feature change)?**
----


**Does this PR introduce a breaking change?**
NO


**Please check if the PR fulfills these requirements**
- [ ] This PR is against the `develop` branch. (Please do not submit PR's to the master branch)
- [ ] The commit message follows our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
